### PR TITLE
Add a Dockerfile to build the monitor image.

### DIFF
--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -7,12 +7,12 @@ COPY ./src/runtime /workdir/src/runtime
 WORKDIR /workdir/src/runtime
 RUN CGO_ENABLED=1 GOFLAGS=-tags=strictfipsruntime make monitor
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-COPY --from=builder /workdir/src/runtime/kata-monitor /usr/bin/kata-monitor
-
 # Add only required capabilities for the monitor
-RUN chmod u-s /usr/bin/kata-monitor
-RUN setcap "cap_dac_override+eip" /usr/bin/kata-monitor
+RUN chmod u-s kata-monitor
+RUN setcap "cap_dac_override+eip" kata-monitor
+
+FROM registry.access.redhat.com/ubi9
+COPY --from=builder /workdir/src/runtime/kata-monitor /usr/bin/kata-monitor
 
 CMD ["-h"]
 ENTRYPOINT ["/usr/bin/kata-monitor"]

--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.7 AS builder
+
+USER root
+COPY ./VERSION /workdir/VERSION
+COPY ./.git /workdir/.git
+COPY ./src/runtime /workdir/src/runtime
+WORKDIR /workdir/src/runtime
+RUN CGO_ENABLED=1 GOFLAGS=-tags=strictfipsruntime make monitor
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY --from=builder /workdir/src/runtime/kata-monitor /usr/bin/kata-monitor
+
+# Add only required capabilities for the monitor
+RUN chmod u-s /usr/bin/kata-monitor
+RUN setcap "cap_dac_override+eip" /usr/bin/kata-monitor
+
+CMD ["-h"]
+ENTRYPOINT ["/usr/bin/kata-monitor"]


### PR DESCRIPTION
This will be used by our downstream build process. Keeping it in our fork for now.