### PR TITLE
osc-monitor: enable hermetic build

### DIFF
--- a/.tekton/osc-monitor-pull-request.yaml
+++ b/.tekton/osc-monitor-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile.monitor
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "./src/runtime"}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -99,7 +101,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/osc-monitor-push.yaml
+++ b/.tekton/osc-monitor-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-monitor:{{revision}}
   - name: dockerfile
     value: Dockerfile.monitor
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "./src/runtime"}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -96,7 +98,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -5,7 +5,10 @@ COPY ./VERSION /workdir/VERSION
 COPY ./.git /workdir/.git
 COPY ./src/runtime /workdir/src/runtime
 WORKDIR /workdir/src/runtime
-RUN CGO_ENABLED=1 GOFLAGS=-tags=strictfipsruntime make monitor
+# Using the "SKIP_GO_VERSION_CHECK" flag to skip version checcking, because it
+# requires yq, which then gets installed at build time.
+# In a hermetic build environment, this is causing failure.
+RUN SKIP_GO_VERSION_CHECK=true CGO_ENABLED=1 GOFLAGS=-tags=strictfipsruntime make monitor
 
 # Add only required capabilities for the monitor
 RUN chmod u-s kata-monitor


### PR DESCRIPTION
- Enabling pre-fetching for go code.
- Enabling hermetic build.

Fixes: [KATA-3829](https://issues.redhat.com//browse/KATA-3829)