### PR TITLE
osc-monitor: update to go 1.23.9

### DIFF
--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23-1749052980 AS builder
 
 USER root
 COPY ./VERSION /workdir/VERSION


### PR DESCRIPTION
Rather than specifying the minor version for go, we should be looking for 1.23, and let the Mintmaker update get us the latest version.

This PR brings us to go 1.23.9

Fixes: [KATA-3832](https://issues.redhat.com//browse/KATA-3832)
