### PR TITLE
konflux: add a configuration for Mintmaker to avoid some updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>konflux-ci/mintmaker-presets:docker"],
+    "dockerfile": {
+        "ignorePaths": [
+            "**/tools/**"
+        ]
+    },
+    "gomod": {
+        "ignorePaths": [
+            "**/tools/**"
+        ]
+    }
+    
+}


### PR DESCRIPTION
This repository is a fork that we use only to build the osc-monitor image. We don't need to get updates for dockerfiles or go dependencies on any of the sources in this repository appart from kata monitor (i.e: src/runtime).

This commit adds a renovate.json file that specifies some folders to ignore when looking for updates. It is set at the root of the default branch (main) as this is where Mintmaker will look for it.

See documentation:
https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#create-your-custom-configuration