### PR TITLE
osc-monitor: fix the pipeline name for branch 1.10

### DIFF
--- a/.tekton/osc-monitor-pull-request.yaml
+++ b/.tekton/osc-monitor-pull-request.yaml
@@ -15,7 +15,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
     appstudio.openshift.io/component: osc-monitor-v1-10
     pipelines.appstudio.openshift.io/type: build
-  name: osc-monitor-on-pull-request
+  name: osc-monitor-v1-10-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:

--- a/.tekton/osc-monitor-push.yaml
+++ b/.tekton/osc-monitor-push.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
     appstudio.openshift.io/component: osc-monitor-v1-10
     pipelines.appstudio.openshift.io/type: build
-  name: osc-monitor-on-push
+  name: osc-monitor-v1-10-on-push
   namespace: ose-osc-tenant
 spec:
   params:


### PR DESCRIPTION
The pipeline's name need to contain the component's name.