### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for osc-monitor

### DIFF
--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -18,7 +18,8 @@ FROM registry.access.redhat.com/ubi9
 COPY --from=builder /workdir/src/runtime/kata-monitor /usr/bin/kata-monitor
 
 # Red Hat labels
-LABEL name="openshift-sandboxed-containers-operator-monitor" \
+LABEL name="openshift-sandboxed-containers/osc-monitor-rhel9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
 version="1.10.1" \
 com.redhat.component="osc-monitor-container" \
 summary="osc-monitor provides the kata-monitor binary to expose sandboxed containers custom metrics" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
