### PR TITLE
[1.10] chore(KONFLUX-6210): fix and set name and cpe label for osc-monitor

### DIFF
--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -20,7 +20,7 @@ COPY --from=builder /workdir/src/runtime/kata-monitor /usr/bin/kata-monitor
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-monitor-rhel9" \
 cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
-version="1.10.2" \
+version="1.10.3" \
 com.redhat.component="osc-monitor-container" \
 summary="osc-monitor provides the kata-monitor binary to expose sandboxed containers custom metrics" \
 maintainer="support@redhat.com" \


### PR DESCRIPTION
Backporting https://github.com/openshift/kata-containers/pull/142 to the 1.10 branch