### PR TITLE
konflux: disable Mintmaker check for rust dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,8 @@
     },
     "gomod": {
         "enabled": false
+    },
+    "cargo": {
+        "enabled": false
     }
 }


### PR DESCRIPTION
We're getting a huge number of PRs from Mintmaker, that we can't handle properly. It makes the PR list difficult to navigate, but also prevents Mintmaker from doing its job: since there is a limit on the number of PRs it opens, new PRs are not created anymore. This prevents us from getting important updates, like Docker base images, or Konflux's tasks references.

At this moment, it is more important for us to get Dockerfile and Konflux updates than it is to manage go dependencies. We can make our own dependency update in a manual, controlled process. Mintmaker is actually not helping here.

This can be revisited at a later time if/when we get time to understand how we can include those updates in our workflow.