### PR TITLE
kata-monitor: Switch base image to UBI micro

### DIFF
--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -14,7 +14,7 @@ RUN SKIP_GO_VERSION_CHECK=true CGO_ENABLED=1 GOFLAGS=-tags=strictfipsruntime mak
 RUN chmod u-s kata-monitor
 RUN setcap "cap_dac_override+eip" kata-monitor
 
-FROM registry.access.redhat.com/ubi9
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.7-1773894938
 COPY --from=builder /workdir/src/runtime/kata-monitor /usr/bin/kata-monitor
 
 # Red Hat labels


### PR DESCRIPTION
The `kata-monitor` is a standalone binary with no external dependencies. Let's base the image on UBI micro to reduce its attack surface.

Fixes https://redhat.atlassian.net/browse/KATA-4962