### PR TITLE
mintmaker: limit Dockerfile updates to the files we use downstream

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,8 @@
         "https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json?raw=true"
     ],
     "dockerfile": {
-        "ignorePaths": [
-            "**/tools/**",
-            "**/tests/**",
-            "**/vendor/**"
+        "includePaths": [
+            "Dockerfile.monitor"
         ]
     },
     "github-actions": {


### PR DESCRIPTION
This is to make sure that mintmaker won't try to bump versions in upstream files.

Based on Julien's work in :

https://github.com/openshift/cloud-api-adaptor/pull/436