### PR TITLE
kata-monitor: Switch to UBI minimal

### DIFF
--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -14,7 +14,8 @@ RUN SKIP_GO_VERSION_CHECK=true CGO_ENABLED=1 GOFLAGS=-tags=strictfipsruntime mak
 RUN chmod u-s kata-monitor
 RUN setcap "cap_dac_override+eip" kata-monitor
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.7-1773894938
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
+
 COPY --from=builder /workdir/src/runtime/kata-monitor /usr/bin/kata-monitor
 
 # Red Hat labels


### PR DESCRIPTION
UBI micro isn't suited for FIPS compliance according to AI bots from the OLM team. We'd need to add and configure openssl manually, which is discouraged.

Switch to UBI minimal.